### PR TITLE
Add numac number as eli:id_local

### DIFF
--- a/src/main/java/be/fedict/lodtools/sbmb/LegalDocWriterCSV.java
+++ b/src/main/java/be/fedict/lodtools/sbmb/LegalDocWriterCSV.java
@@ -88,14 +88,14 @@ public class LegalDocWriterCSV implements LegalDocWriter {
 		try (BufferedWriter w = Files.newBufferedWriter(outfile);
 			CSVWriter csv = new CSVWriter(w)) {
 			
-			String[] header = { "ID", "JUSTEL", "DOCTYPE", 
+			String[] header = { "ID", "JUSTEL", "DOCTYPE", "NUMAC",
 								"DOCDATE", "PUBDATE", "LANG", 
 								"TYPE" , "SOURCE", "TITLE" };	
 			csv.writeNext(header);
 			
 			for (LegalDoc doc: docs) {
 				String[] row = {
-					doc.getId(), doc.getJustel().toString(), type,
+					doc.getId(), doc.getJustel().toString(), type, doc.getLocalId(),
 					toDate(doc.getDocDate()), toDate(doc.getPubDate()), doc.getLang(),
 					types.get(doc.getLang()), doc.getSource(), doc.getTitle() };
 				csv.writeNext(row);

--- a/src/main/java/be/fedict/lodtools/sbmb/LegalDocWriterRDF.java
+++ b/src/main/java/be/fedict/lodtools/sbmb/LegalDocWriterRDF.java
@@ -132,6 +132,8 @@ public class LegalDocWriterRDF implements LegalDocWriter {
 					m.add(id, ELI.DATE_PUBLICATION, pubDate);
 				}
 				
+				m.add(id, ELI.ID_LOCAL, F.createLiteral(doc.getLocalId()));
+				
 				// Alias / sameas
 				String lang = doc.getLang();
 				String t = types.get(lang);

--- a/src/main/java/be/fedict/lodtools/sbmb/PageParser.java
+++ b/src/main/java/be/fedict/lodtools/sbmb/PageParser.java
@@ -132,6 +132,9 @@ public class PageParser {
 		for (Element link : links) {
 			try {
 				URL u = new URL(link.attr("href"));
+				String urlParts[] = u.getPath().split("/");
+				String numac = urlParts[6];
+				doc.setLocalId(numac);
 				if (link.ownText().trim().startsWith("Justel")) {
 					doc.setId(u.toString().replaceFirst("/justel", ""));
 					doc.setJustel(u);

--- a/src/main/java/be/fedict/lodtools/sbmb/helper/ELI.java
+++ b/src/main/java/be/fedict/lodtools/sbmb/helper/ELI.java
@@ -44,6 +44,7 @@ public class ELI {
 
 	public static final IRI DATE_DOCUMENT;
 	public static final IRI DATE_PUBLICATION;
+	public static final IRI ID_LOCAL;
 	public static final IRI EMBODIES;
 	public static final IRI FORMAT_PROP;
 	public static final IRI IS_EMBODIED_BY;
@@ -67,6 +68,7 @@ public class ELI {
 		
 		DATE_DOCUMENT = F.createIRI(NAMESPACE, "date_document");
 		DATE_PUBLICATION = F.createIRI(NAMESPACE, "date_publication");
+		ID_LOCAL = F.createIRI(NAMESPACE, "id_local");
 		EMBODIES = F.createIRI(NAMESPACE, "embodies");
 		FORMAT_PROP = F.createIRI(NAMESPACE, "format");
 		IS_EMBODIED_BY = F.createIRI(NAMESPACE, "is_embodied_by");

--- a/src/main/java/be/fedict/lodtools/sbmb/helper/LegalDoc.java
+++ b/src/main/java/be/fedict/lodtools/sbmb/helper/LegalDoc.java
@@ -35,6 +35,7 @@ import java.time.LocalDate;
  */
 public class LegalDoc {
 	private String id;
+	private String localId;
 	private String title;
 	private String source;
 	private String lang;
@@ -59,6 +60,24 @@ public class LegalDoc {
 	 */
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	/**
+	 * Get local identifier ("NUMAC")
+	 * 
+	 * @return identifier
+	 */
+	public String getLocalId() {
+		return localId;
+	}
+
+	/**
+	 * Set local identifier ("NUMAC")
+	 * 
+	 * @param id identifier 
+	 */
+	public void setLocalId(String localId) {
+		this.localId = localId;
 	}
 
 	/**


### PR DESCRIPTION
In order to easily be able to query legal resources based on their Numac-number, we added those as an extra property to parse. The RDF-DocWriter serializes this property under the `http://data.europa.eu/eli/ontology#id_local`-predicate, which is meant for country-local identifiers such as the Belgian "Numac".

cc @barthanssens 